### PR TITLE
chore(deps): upgrade reqwest to 0.13 with middleware and retry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ rust-version = "1.85.1"
 
 [dependencies]
 tracing = "0.1"
-reqwest = { version = "0.12", default-features = false, features = [
+reqwest = { version = "0.13", default-features = false, features = [
     "blocking",
-    "rustls-tls",
+    "rustls",
     "json",
 ] }
 serde = { version = "1", features = ["derive"] }
@@ -33,8 +33,8 @@ once_cell = { version = "1.19", optional = true }
 # For retry logic with exponential backoff (sync)
 backon = "1.3"
 # For async retry middleware
-reqwest-middleware = { version = "0.4", optional = true }
-reqwest-retry = { version = "0.7", optional = true }
+reqwest-middleware = { version = "0.5", optional = true }
+reqwest-retry = { version = "0.9", optional = true }
 # For async stream pagination
 async-stream = { version = "0.3", optional = true }
 


### PR DESCRIPTION
## Summary
- Upgrade reqwest 0.12 → 0.13
- Upgrade reqwest-middleware 0.4 → 0.5
- Upgrade reqwest-retry 0.7 → 0.9
- Only breaking change: `rustls-tls` feature renamed to `rustls`

Supersedes #16, #17, #18 (individual Dependabot PRs that fail CI when applied alone).

**Bonus:** reqwest-retry 0.9 drops the `instant` crate dependency, resolving #6.

## Test plan
- [x] `cargo check --all-features` passes
- [x] `cargo clippy --all-features -- -D warnings` passes
- [x] All 104 tests pass
- [x] `cargo tree --all-features | grep instant` returns nothing

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)